### PR TITLE
Wait until all images have loaded prior to scrolling down.

### DIFF
--- a/forum/styles/prosilver/template/overall_header.html
+++ b/forum/styles/prosilver/template/overall_header.html
@@ -106,7 +106,7 @@
 <script type="text/javascript" src="{T_TEMPLATE_PATH}/jquery.fancybox.js?v=10"></script>
 <script type="text/javascript" src="./styles/prosilver/template/handlebars-v2.0.0.js?v=13"></script>
 
-<link href="{T_THEME_PATH}/sitechat.css?v=05" rel="stylesheet" type="text/css" media="screen" />
+<link href="{T_THEME_PATH}/sitechat.css?v=06" rel="stylesheet" type="text/css" media="screen" />
 <script type="text/javascript" src="./styles/prosilver/template/sitechat.js?v=13"></script>
 <!-- ENDIF -->
 <!-- IF S_CONTENT_DIRECTION eq 'rtl' -->

--- a/forum/styles/prosilver/template/sitechat.js
+++ b/forum/styles/prosilver/template/sitechat.js
@@ -527,8 +527,13 @@ var siteChat = (function() {
 			$inputBuffer.focus();
 			chatWindow.save();
 		}
-		else
-			$outputBuffer.scrollTop($outputBuffer.scrollHeight);
+		else {
+			$outputBuffer.scrollTop($outputBuffer[0].scrollHeight);
+
+			$outputBuffer.find("img").on("load", function(e) {
+				$outputBuffer.scrollTop($outputBuffer[0].scrollHeight);
+			});
+		}
 	};
 
 	siteChat.getMessageMapKeyUserId = function(siteChatConversationMessage) {
@@ -589,7 +594,7 @@ var siteChat = (function() {
 
 		if(isScrolledToBottom)
 			$outputBuffer.get(0).scrollTop = $outputBuffer.get(0).scrollHeight;
-
+		
 		if(save)
 			chatWindow.save();
 	};

--- a/forum/styles/scumobile/template/overall_header.html
+++ b/forum/styles/scumobile/template/overall_header.html
@@ -97,7 +97,7 @@
 	<link href="{T_THEME_PATH}/bidi.css" rel="stylesheet" type="text/css" media="screen, projection" />
 <!-- ENDIF -->
 <!-- IF S_CHAT -->
-<link href="{T_THEME_PATH}/sitechat.css?v=04" rel="stylesheet" type="text/css" media="screen" />
+<link href="{T_THEME_PATH}/sitechat.css?v=05" rel="stylesheet" type="text/css" media="screen" />
 <script type="text/javascript" src="./styles/prosilver/template/handlebars-v2.0.0.js"></script>
 <script type="text/javascript" src="./styles/prosilver/template/sitechat.js?v=10"></script>
 


### PR DESCRIPTION
Sitechat windows previously scrolled to the bottom on page load after everything had been loaded into the DOM. However, images will take a few milliseconds to load, and impact the height of the window buffer slightly if the user entered a single-lined message. This change will adjust the scroll offset after each image from the initial messages has been loaded.
