### PR TITLE
Only redirect on mafiascum.net

### DIFF
--- a/forum/.htaccess
+++ b/forum/.htaccess
@@ -1,6 +1,4 @@
 RewriteEngine on
 
-RewriteCond %{HTTP_HOST} !forum.mafiascum.net
-RewriteCond %{HTTP_HOST} !msdev
-RewriteCond %{HTTP_HOST} !localhost
+RewriteCond %{HTTP_HOST} mafiascum.net|www.mafiascum.net
 RewriteRule (.*) http://forum.mafiascum.net/$1 [NC,R=301]

--- a/wiki/.htaccess
+++ b/wiki/.htaccess
@@ -1,6 +1,4 @@
 RewriteEngine on
 
-RewriteCond %{HTTP_HOST} !wiki.mafiascum.net
-RewriteCond %{HTTP_HOST} !msdev
-RewriteCond %{HTTP_HOST} !localhost
+RewriteCond %{HTTP_HOST} mafiascum.net|www.mafiascum.net
 RewriteRule (.*) http://wiki.mafiascum.net/$1 [NC,R=301]


### PR DESCRIPTION
Currently the .htaccess files just check to make sure you aren't localhost before serving the redirect. Instead, check if the domain is mafiascum.net or www.mafiascum.net.