### PR TITLE
Strip non BMP characters & skip failed message stores.

### DIFF
--- a/java/SiteChatServer/src/net/mafiascum/util/StringUtil.java
+++ b/java/SiteChatServer/src/net/mafiascum/util/StringUtil.java
@@ -718,4 +718,10 @@ public class StringUtil extends MSUtil {
     
     return DigestUtils.sha1Hex(str);
   }
+  
+  public String removeNonBmp(String str) {
+    if(str == null)
+      return null;
+    return str.replaceAll("[^\\u0000-\\uFFFF]", "");
+  }
 }

--- a/java/SiteChatServer/src/net/mafiascum/web/sitechat/server/SiteChatUtil.java
+++ b/java/SiteChatServer/src/net/mafiascum/web/sitechat/server/SiteChatUtil.java
@@ -2,6 +2,8 @@ package net.mafiascum.web.sitechat.server;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -110,8 +112,19 @@ public class SiteChatUtil extends MSUtil {
   }
   
   public void putNewSiteChatConversationMessages(Connection connection, List<SiteChatConversationMessage> siteChatConversationMessages) throws SQLException {
-    BatchInsertStatement batchInsertStatement = new BatchInsertStatement(connection, "siteChatConversationMessage", siteChatConversationMessages.size() + 1);
-    putNewSiteChatConversationMessages(siteChatConversationMessages, batchInsertStatement);
+    for(SiteChatConversationMessage message : siteChatConversationMessages) {
+      try {
+        BatchInsertStatement batchInsertStatement = new BatchInsertStatement(connection, "siteChatConversationMessage", 1);
+        putNewSiteChatConversationMessages(new ArrayList<>(Arrays.asList(message)), batchInsertStatement);
+      }
+      catch(Exception exception) {
+        logger.error("Error storing message.", exception);
+      }
+    }
+  }
+  
+  public void putSiteChatConversationMessage(Connection connection, SiteChatConversationMessage message) throws SQLException {
+    message.store(connection);
   }
   
   public int getTopSiteChatConversationMessageId(Connection connection) throws SQLException {

--- a/java/SiteChatServer/src/net/mafiascum/web/sitechat/server/inboundpacket/operator/SiteChatInboundSendMessagePacketOperator.java
+++ b/java/SiteChatServer/src/net/mafiascum/web/sitechat/server/inboundpacket/operator/SiteChatInboundSendMessagePacketOperator.java
@@ -67,6 +67,9 @@ public class SiteChatInboundSendMessagePacketOperator extends SiteChatInboundSig
       sendMessagePacket.setMessage(sendMessagePacket.getMessage().substring(0, siteChatUtil.MAX_SITE_CHAT_CONVERSATION_MESSAGE_LENGTH));
     }
     
+    //Remove out of range characters.
+    sendMessagePacket.setMessage(stringUtil.removeNonBmp(sendMessagePacket.getMessage()));
+    
     if(sendMessagePacket.getMessage().startsWith("/"))
       processor.processChannelCommand(descriptor, user.getUser(), sendMessagePacket.getMessage());
     else {

--- a/java/SiteChatServer/src/net/mafiascum/web/sitechat/server/inboundpacket/operator/test/SiteChatInboundLoadMessagesPacketOperatorTest.java
+++ b/java/SiteChatServer/src/net/mafiascum/web/sitechat/server/inboundpacket/operator/test/SiteChatInboundLoadMessagesPacketOperatorTest.java
@@ -20,6 +20,7 @@ import net.mafiascum.web.sitechat.server.conversation.SiteChatConversationMessag
 import net.mafiascum.web.sitechat.server.inboundpacket.SiteChatInboundLoadMessagesPacket;
 import net.mafiascum.web.sitechat.server.inboundpacket.operator.SiteChatInboundLoadMessagesPacketOperator;
 import net.mafiascum.web.sitechat.server.outboundpacket.SiteChatOutboundLoadMessagesPacket;
+import net.mafiascum.web.sitechat.server.outboundpacket.SiteChatOutboundPacket;
 import net.mafiascum.web.sitechat.server.outboundpacket.SiteChatOutboundPacketType;
 import net.mafiascum.web.sitechat.server.user.UserData;
 
@@ -53,7 +54,7 @@ public class SiteChatInboundLoadMessagesPacketOperatorTest {
     operator.setSiteChatUtil(SiteChatUtil.get());
     operator.process(processor, userData, descriptor, new Gson().toJson(packet));
     
-    verify(processor, times(1)).sendToDescriptor(any(), any());
+    verify(processor, times(1)).sendToDescriptor(any(), (SiteChatOutboundPacket)any());
     Assert.assertEquals(packet.getConversationKey(), outboundPacketCaptor.getValue().getConversationKey());
     Assert.assertEquals(SiteChatOutboundPacketType.loadMessages.getStandardName(), outboundPacketCaptor.getValue().getCommand());
     Assert.assertEquals(3, outboundPacketCaptor.getValue().getMessages().size());


### PR DESCRIPTION
Since we batch store messages & do not clear the queue if there is a storage error, we are effectively blocking the server message processing if any such error occurs. We are only supporting UTF-8 (for now). Anyone submitting an emoji breaks storage in the DB. Until we can support 4-byte characters, we can for now strip all the non BMP characters from message inputs, and also improve the message storage queue by clearing it even if one of the messages fails. This should result in a bad message never causing blockage.