### PR TITLE
Fixed the php error in signature edit page

### DIFF
--- a/forum/includes/message_parser.php
+++ b/forum/includes/message_parser.php
@@ -51,12 +51,14 @@ class bbcode_firstpass extends bbcode
 		{
 			if (isset($bbcode_data['disabled']) && $bbcode_data['disabled'])
 			{
-				foreach ($bbcode_data['regexp'] as $regexp => $replacement)
-				{
-					if (preg_match($regexp, $this->message))
+				if (is_array($bbcode_data['regexp']) || is_object($bbcode_data['regexp'])){
+					foreach ($bbcode_data['regexp'] as $regexp => $replacement)
 					{
-						$this->warn_msg[] = sprintf($user->lang['UNAUTHORISED_BBCODE'] , '[' . $bbcode_name . ']');
-						continue;
+						if (preg_match($regexp, $this->message))
+						{
+							$this->warn_msg[] = sprintf($user->lang['UNAUTHORISED_BBCODE'] , '[' . $bbcode_name . ']');
+							continue;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The php error in signature edit page (when a bbcode was included) is fixed. The problem was that a foreach was trying to iterate over an empty array when there were no disabled bbcodes in input.